### PR TITLE
Use bash to run the script, added a shebang

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 declare -A tests
 tests[aleph]=aleph.http
 tests[incanter]=incanter.core


### PR DESCRIPTION
The script was failing when trying to run under zsh on OSX. zsh's declare command doesn't allow arrays to be assigned as they're declared.

For maximum portability use a shebang on shell scripts.
